### PR TITLE
User could provide log validator for game-loop test. Enabled retry logic for failed tests.

### DIFF
--- a/firebase-test-lab/README.md
+++ b/firebase-test-lab/README.md
@@ -107,7 +107,7 @@ jobs:
             test_type: ${{ test_type }}
     ```
 
-    Example of authenticating via `workload_identity_provider` and `service_account` (Workload Identity Federation). See [Setting up Workload Identity Federation](https://github.com/google-github-actions/auth#setup) for more information.
+    Example of authenticating via `workload_identity_provider` and `service_account` (Workload Identity Federation). See [Setting up Workload Identity Federation](https://github.com/google-github-actions/auth#setup) for more information. (Note: For interal Google Cloud projects, Workload Identity Federation cannot be used by default. Please use Overground to modify Org Policy first.)
     ```yml
     jobs:
     ftl_testing:

--- a/firebase-test-lab/README.md
+++ b/firebase-test-lab/README.md
@@ -1,6 +1,6 @@
 # `firebase-test-lab` GitHub Action
 
-This GitHub Action sends your apps to Firebase Test Lab, which lets you test your apps on a range of devices and configurations, and generate test summary as output.
+This GitHub Action leverages gcloud CLI ([Android](https://firebase.google.com/docs/test-lab/android/command-line), [iOS](https://firebase.google.com/docs/test-lab/ios/command-line)), which could send your apps to Firebase Test Lab and lets you test your apps on a range of devices and configurations at once. Once all tests finish running, this GitHub Action will generate a summary in the JSON format.
 
 ## Prerequisite
 
@@ -35,7 +35,8 @@ jobs:
 
 -   `testapp_dir`: Testapps under this dir that will be tested. For XCTest, make sure you [packaged your app](https://firebase.google.com/docs/test-lab/ios/run-xctest#package-app) first. [TODO: needs better design] For instrumentation tests, you also need to package the apks: make sure the test apk name contains string "test" and the app apk doesn't (e.g. app-debug-unaligned.apk & app-debug-test-unaligned.apk -> app.zip).
 
--   `arg_groups` [**robo** & **instrumentation** test only]: Arguments in a YAML-formatted argument file, separate by ";". If there are conflicts between `arg_groups` and other inputs, arguments in `arg_groups` will be overrided by other inputs.
+-   `arg_groups` [**robo** & **instrumentation** test only]: Arguments in a YAML-formatted argument file, separate by ";". If there are conflicts between `arg_groups` and other inputs, arguments in `arg_groups` will be overrided by other inputs. Run [gcloud topic arg-files](https://cloud.google.com/sdk/gcloud/reference/topic/arg-files) for more information about argument files.
+    
     Here are the contents of a YAML argument file which is stored in a file named demo_arg.yaml:
     ```yml
     unit-tests:
@@ -86,9 +87,12 @@ jobs:
 
 -   `timeout` [default: 600s]: The maximum duration you want your test to run. You can enter an integer to represent the duration in seconds, or an integer and enumeration to represent the duration as a longer unit of time. 
 
+-   `additional_flags`: Additional [gcloud firebase test](https://cloud.google.com/sdk/gcloud/reference/firebase/test) flags and values that may be used. e.g. `--xcode-version=11.3` for XCTest. 
+
 -   `max_attempts` [default: 1]: Max retry attempts when test on FTL failed. 
 
 -   (Optional) The following inputs are for installation and authenticating to Google Cloud. Firebase Test Lab GitHub Action leverages [google-github-actions/auth](https://github.com/google-github-actions/auth) and [google-github-actions/setup-gcloud](https://github.com/google-github-actions/setup-gcloud). 
+    
     Example of authenticating via `credentials_json` (Service Account Key JSON). See [Creating and managing Google Cloud Service Account Keys](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) for more information.
     ```yml
     jobs:

--- a/firebase-test-lab/README.md
+++ b/firebase-test-lab/README.md
@@ -1,0 +1,170 @@
+# `firebase-test-lab` GitHub Action
+
+This GitHub Action sends your apps to Firebase Test Lab, which lets you test your apps on a range of devices and configurations, and generate test summary as output.
+
+## Prerequisite
+
+-   A Firebase project. Follow the instructions [Setting up a Firebase project and registering apps](https://firebase.google.com/docs/projects/learn-more#setting_up_a_firebase_project_and_registering_apps).
+
+-   Have a service account and enable required APIs. Create a service account with an Editor role in the [Google Cloud Console](https://console.cloud.google.com/iam-admin/serviceaccounts/) and then activate it (see the [gcloud auth activate-service-account documentation](https://cloud.google.com/sdk/gcloud/reference/auth/activate-service-account) to learn how). Using the service account to log into Google and go to the [Google Developers Console API Library page](https://console.developers.google.com/apis/library). Enable the **Google Cloud Testing API** and the **Cloud Tool Results API** by typing their names into the search box at the top of the console and clicking Enable API.
+
+-   Install and authorize the Google Cloud SDK. Firebase Test Lab GitHub Action will do this step for you if you provides **Google Cloud Service Account Key JSON** or **Workload Identity Federation**. Alternatively, you could do it by yourself. For more infomation: [google-github-actions/auth](https://github.com/google-github-actions/auth).
+
+-   Python 2.7+. All the [GitHub-hosted runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners) have Python 2.7+ preinstalled. But if you are using a [self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners), please have Python installed first.
+
+## Usage
+```yml
+jobs:
+  ftl_testing:
+    # ...
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build your Apps
+        ...
+      - id: ftl_test
+        uses: FirebaseExtended/github-actions/firebase-test-lab@v1.1
+        with:
+          testapp_dir: ${{ testapp_dir }}
+          test_type: ${{ test_type }}
+```
+
+## Inputs
+
+-   `test_type`: One of the following four test types that FTL supports: [xctest](https://firebase.google.com/docs/test-lab/ios/run-xctest), [instrumentation](https://firebase.google.com/docs/test-lab/android/instrumentation-test), [robo](https://firebase.google.com/docs/test-lab/android/robo-ux-test), [game-loop](https://firebase.google.com/docs/test-lab/android/game-loop).
+
+-   `testapp_dir`: Testapps under this dir that will be tested. For XCTest, make sure you [packaged your app](https://firebase.google.com/docs/test-lab/ios/run-xctest#package-app) first. [TODO: needs better design] For instrumentation tests, you also need to package the apks: make sure the test apk name contains string "test" and the app apk doesn't (e.g. app-debug-unaligned.apk & app-debug-test-unaligned.apk -> app.zip).
+
+-   `arg_groups` [**robo** & **instrumentation** test only]: Arguments in a YAML-formatted argument file, separate by ";". If there are conflicts between `arg_groups` and other inputs, arguments in `arg_groups` will be overrided by other inputs.
+    Here are the contents of a YAML argument file which is stored in a file named demo_arg.yaml:
+    ```yml
+    unit-tests:
+      type: instrumentation
+      app: path/to/excelsior.apk
+      test: path/to/excelsior-test.apk  # the unit tests
+      timeout: 10m
+      device-ids: NexusLowRes
+      include: [supported-versions, supported-locales]
+    
+    unit-tests-2:
+    ...
+    ```
+    `arg_groups` usage example:
+    ```yml
+    jobs:
+    ftl_testing:
+        # ...
+
+        steps:
+        - uses: actions/checkout@v3
+        - name: Build your Apps
+            ...
+        - id: ftl_test
+          uses: FirebaseExtended/github-actions/firebase-test-lab@v1.1
+          with:
+            arg_groups: demo_arg.yaml:unit-tests;demo_arg.yaml:unit-tests-2
+    ```
+
+-   `test_devices`: Devices used for testing, separate by ";". You could find out all the available devices in Test Lab here: [Android](https://firebase.google.com/docs/test-lab/android/available-testing-devices), [iOS](https://firebase.google.com/docs/test-lab/ios/available-testing-devices).
+    `test_devices` usage example:
+    ```yml
+    jobs:
+    ftl_testing:
+        # ...
+
+        steps:
+        - uses: actions/checkout@v3
+        - name: Build your Apps
+            ...
+        - id: ftl_test
+          uses: FirebaseExtended/github-actions/firebase-test-lab@v1.1
+          with:
+            testapp_dir: ${{ testapp_dir }}
+            test_type: ${{ test_type }}
+            test_devices: model=redfin,version=30;model=oriole,version=33
+    ```
+
+-   `timeout` [default: 600s]: The maximum duration you want your test to run. You can enter an integer to represent the duration in seconds, or an integer and enumeration to represent the duration as a longer unit of time. 
+
+-   `max_attempts` [default: 1]: Max retry attempts when test on FTL failed. 
+
+-   (Optional) The following inputs are for installation and authenticating to Google Cloud. Firebase Test Lab GitHub Action leverages [google-github-actions/auth](https://github.com/google-github-actions/auth) and [google-github-actions/setup-gcloud](https://github.com/google-github-actions/setup-gcloud). 
+    Example of authenticating via `credentials_json` (Service Account Key JSON). See [Creating and managing Google Cloud Service Account Keys](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) for more information.
+    ```yml
+    jobs:
+    ftl_testing:
+        # ...
+
+        steps:
+        - uses: actions/checkout@v3
+        - name: Build your Apps
+            ...
+        - id: ftl_test
+          uses: FirebaseExtended/github-actions/firebase-test-lab@v1.1
+          with:
+            credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+            testapp_dir: ${{ testapp_dir }}
+            test_type: ${{ test_type }}
+    ```
+
+    Example of authenticating via `workload_identity_provider` and `service_account` (Workload Identity Federation). See [Setting up Workload Identity Federation](https://github.com/google-github-actions/auth#setup) for more information.
+    ```yml
+    jobs:
+    ftl_testing:
+        # ...
+
+        steps:
+        - uses: actions/checkout@v3
+        - name: Build your Apps
+            ...
+        - id: ftl_test
+          uses: FirebaseExtended/github-actions/firebase-test-lab@v1.1
+          with:
+            workload_identity_provider: ${{ workload_identity_provider }}
+            service_account: ${{ service_account }}
+            testapp_dir: ${{ testapp_dir }}
+            test_type: ${{ test_type }}
+    ```
+
+## Output
+
+This GitHub Action will collection all the test results and generate a summary in the JSON format.
+
+Output usage:
+```yml
+- id: ftl_test
+    uses: FirebaseExtended/github-actions/firebase-test-lab@v1.1
+    with:
+      ...
+- run: echo '${{ steps.ftl_test.outputs.test_summary }}'
+```
+
+Test summary example:
+```json
+{
+  "project_id": ${project_id},
+  "apps": [
+    { # app_1
+      "attempt": ${attempt_num},
+      "cmd": ${cmd},
+      "return_code": ${return_code}, # Script exit codes: https://firebase.google.com/docs/test-lab/ios/command-line#script-exit-codes
+      "testapp_path": ${app_path},
+      "test_type": ${test_type}, # game-loop, xctest, robo, instrumentation
+      "ftl_link": ${ftl_link}, # Test Lab page from Firebase console
+      "raw_result_link":  ${raw_result_link}, # Google Cloud page that stores all the test artifacts
+      "devices": [
+        { # device_1
+          "device_axis": ${device_axis},
+          "outcome": ${outcome}, # Passed, Failed, Inconclusive, Skipped
+        },
+        { # device_2
+          ... 
+        }
+      ],
+    },
+    { # app_2
+      ...
+    }
+  ]
+}
+```

--- a/firebase-test-lab/README.md
+++ b/firebase-test-lab/README.md
@@ -140,7 +140,7 @@ Output usage:
 ```
 
 Test summary example:
-```json
+```
 {
   "project_id": ${project_id},
   "apps": [

--- a/firebase-test-lab/action.yml
+++ b/firebase-test-lab/action.yml
@@ -45,6 +45,7 @@ inputs:
     required: false
   max_attempts:
     description: 'Max retries when test on FTL failed.'
+    default: 1
     required: false
   validator:
     description: 'Path of customized python script that validate one game-loop test result.'

--- a/firebase-test-lab/action.yml
+++ b/firebase-test-lab/action.yml
@@ -37,11 +37,17 @@ inputs:
     description: 'Device model used for testing. Separate by ";".'
     required: false
   timeout:
-    description: 'Timeout for one ftl test.'
+    description: 'Timeout for one FTL test.'
     default: '600s'
     required: false
   additional_flags:
     description: 'Additional flags and values that may be used. e.g. --xcode-version=11.3.'
+    required: false
+  max_attempts:
+    description: 'Max retries when test on FTL failed.'
+    required: false
+  validator:
+    description: 'Customized python script that validate one game-loop test result.'
     required: false
   project_id:
     description: 'Firebase Project ID.'
@@ -68,7 +74,7 @@ runs:
     - id: ftl_test
       shell: bash
       run: |
-        test_result=$(python $GITHUB_ACTION_PATH/trigger_ftl_tests.py --arg_groups="${{ inputs.arg_groups }}" --testapp_dir="${{ inputs.testapp_dir }}" --test_type="${{ inputs.test_type }}" --timeout="${{ inputs.timeout }}" --test_devices="${{ inputs.test_devices }}" --additional_flags="${{ inputs.additional_flags }}")
+        test_result=$(python $GITHUB_ACTION_PATH/trigger_ftl_tests.py --arg_groups="${{ inputs.arg_groups }}" --testapp_dir="${{ inputs.testapp_dir }}" --test_type="${{ inputs.test_type }}" --timeout="${{ inputs.timeout }}" --test_devices="${{ inputs.test_devices }}" --additional_flags="${{ inputs.additional_flags }} --max_attempts="${{ inputs.max_attempts }} --validator="${{ inputs.validator }}")
         
         # first character in test_result is the exit code (0 or 1); the rest are the JSON format test summary.
         if [[ ! -z ${test_result} ]]; then

--- a/firebase-test-lab/action.yml
+++ b/firebase-test-lab/action.yml
@@ -74,7 +74,7 @@ runs:
     - id: ftl_test
       shell: bash
       run: |
-        test_result=$(python $GITHUB_ACTION_PATH/trigger_ftl_tests.py --arg_groups="${{ inputs.arg_groups }}" --testapp_dir="${{ inputs.testapp_dir }}" --test_type="${{ inputs.test_type }}" --timeout="${{ inputs.timeout }}" --test_devices="${{ inputs.test_devices }}" --additional_flags="${{ inputs.additional_flags }} --max_attempts="${{ inputs.max_attempts }} --validator="${{ inputs.validator }}")
+        test_result=$(python $GITHUB_ACTION_PATH/trigger_ftl_tests.py --arg_groups="${{ inputs.arg_groups }}" --testapp_dir="${{ inputs.testapp_dir }}" --test_type="${{ inputs.test_type }}" --timeout="${{ inputs.timeout }}" --test_devices="${{ inputs.test_devices }}" --additional_flags="${{ inputs.additional_flags }}" --max_attempts="${{ inputs.max_attempts }}" --validator="${{ inputs.validator }}")
         
         # first character in test_result is the exit code (0 or 1); the rest are the JSON format test summary.
         if [[ ! -z ${test_result} ]]; then

--- a/firebase-test-lab/action.yml
+++ b/firebase-test-lab/action.yml
@@ -47,7 +47,7 @@ inputs:
     description: 'Max retries when test on FTL failed.'
     required: false
   validator:
-    description: 'Customized python script that validate one game-loop test result.'
+    description: 'Path of customized python script that validate one game-loop test result.'
     required: false
   project_id:
     description: 'Firebase Project ID.'

--- a/firebase-test-lab/action.yml
+++ b/firebase-test-lab/action.yml
@@ -48,7 +48,7 @@ inputs:
     default: 1
     required: false
   validator:
-    description: 'Path of customized python script that validate one game-loop test result.'
+    description: '[Experimental] Path of customized python script that validate one game-loop test result.'
     required: false
   project_id:
     description: 'Firebase Project ID.'

--- a/firebase-test-lab/trigger_ftl_tests.py
+++ b/firebase-test-lab/trigger_ftl_tests.py
@@ -210,6 +210,7 @@ def _ftl_run(FLAGS, ftl_cmd, tests_result):
 
 
 def _parse_test_summary(FLAGS, ftl_cmd, result, attempt_num):
+    """There is no better API avaliable. Thus, use Regex to parse test information, and generate test_summary for this testapp"""
     result_log = result.stdout.read()
     logging.info("Test log: %s", result_log)
 
@@ -263,11 +264,14 @@ def _parse_test_summary(FLAGS, ftl_cmd, result, attempt_num):
 
 
 def _validate_results(FLAGS, test_summary):
+  """Returns True if all tests passed; False otherwise"""
   if test_summary.get("return_code") != 0:
     return False
   
   if FLAGS.test_type == GAMELOOP and FLAGS.validator:
     try:
+      # [Experimental] This is for game-loop test only, which could validate test result for one app.
+      # Assume FLAGS.validator it the path of customized python script, and contains function "validate(test_summary)"".
       module = os.path.splitext(FLAGS.validator)[0]
       validator = imp.load_source(module, FLAGS.validator)
       return validator.validate(test_summary)
@@ -325,8 +329,9 @@ def _ftl_cmd_with_flags(FLAGS, testapp_path):
 
 
 def _extract_instrumentation_test(zip_path): 
-  # Android instrumentation tests requires two apks.
+  # Android instrumentation tests requires two apks. 
   # https://firebase.google.com/docs/test-lab/android/command-line#running_your_instrumentation_tests
+  # Please make sure the test apk name contains string "test" and the app apk doesn't.
   with ZipFile(zip_path, 'r') as zipObj:
     output_dir = os.path.splitext(zip_path)[0]
     zipObj.extractall(output_dir)

--- a/firebase-test-lab/trigger_ftl_tests.py
+++ b/firebase-test-lab/trigger_ftl_tests.py
@@ -200,7 +200,7 @@ def _ftl_run(FLAGS, ftl_cmd, tests_result):
     # https://firebase.google.com/docs/test-lab/android/command-line#script_exit_codes
     logging.info("Test done: %s\nReturned code: %s", ftl_cmd, result.returncode)
 
-    test_summary = _parse_test_summary(FLAGS, ftl_cmd, result)
+    test_summary = _parse_test_summary(FLAGS, ftl_cmd, result, attempt_num)
     tests_result.get('apps').append(test_summary)
 
     if _validate_results(FLAGS, test_summary):
@@ -209,7 +209,7 @@ def _ftl_run(FLAGS, ftl_cmd, tests_result):
     attempt_num += 1
 
 
-def _parse_test_summary(FLAGS, ftl_cmd, result):
+def _parse_test_summary(FLAGS, ftl_cmd, result, attempt_num):
     result_log = result.stdout.read()
     logging.info("Test log: %s", result_log)
 
@@ -251,6 +251,7 @@ def _parse_test_summary(FLAGS, ftl_cmd, result):
       outcome_device.append({"device_axis": o_d[1].strip(), "outcome": o_d[0].strip()})
     
     return {
+      "attempt": attempt_num,
       "cmd": ftl_cmd,
       "return_code": result.returncode,
       "testapp_path": testapp_path,

--- a/firebase-test-lab/trigger_ftl_tests.py
+++ b/firebase-test-lab/trigger_ftl_tests.py
@@ -81,6 +81,7 @@ import time
 import argparse
 import logging
 import json
+import imp
 
 from zipfile import ZipFile
 
@@ -185,67 +186,94 @@ def _run_test_on_ftl(FLAGS):
 # This runs in a separate thread, so instead of returning values we store
 # them in test_result so they can be accessed from the main thread.
 def _ftl_run(FLAGS, ftl_cmd, tests_result):
-  logging.info("Testapp sent: %s", ftl_cmd)
-  result = subprocess.Popen(
-      args=ftl_cmd,
-      stdout=subprocess.PIPE,
-      stderr=subprocess.STDOUT,
-      universal_newlines=True, 
-      shell=True)
-  result_log = result.stdout.read()
+  attempt_num = 1
+  while attempt_num <= FLAGS.max_attempts:
+    logging.info("Testapp sent to FTL: %s (attempt %s of %s)", ftl_cmd, attempt_num, FLAGS.max_attempts)
+    result = subprocess.Popen(
+        args=ftl_cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True, 
+        shell=True)
+    while result.poll() is None:
+      time.sleep(1) # Process hasn't exited yet, let's wait some
+    # https://firebase.google.com/docs/test-lab/android/command-line#script_exit_codes
+    logging.info("Test done: %s\nReturned code: %s", ftl_cmd, result.returncode)
 
-  # Use Regex to filter the test information, Until we have better APIs.
-  # Generate test summary by using regex search ftl cmd logs
-  testapp_path = ""
-  testapp_path_search = re.search(r'Uploading \[(.*?)\] to Firebase Test Lab', result_log, re.MULTILINE | re.DOTALL)
-  if testapp_path_search:
-    testapp_path = testapp_path_search.group(1)
+    test_summary = _parse_test_summary(FLAGS, ftl_cmd, result)
+    tests_result.get('apps').append(test_summary)
 
-  ftl_link = ""
-  ftl_link_search = re.search(r'Test results will be streamed to \[(.*?)\]', result_log, re.MULTILINE | re.DOTALL)
-  if ftl_link_search:
-    ftl_link = ftl_link_search.group(1)
- 
-  raw_result_link = ""
-  raw_result_link_search = re.search(r'Raw results will be stored in your GCS bucket at \[(.*?)\]', result_log, re.MULTILINE | re.DOTALL)
-  if raw_result_link_search:
-    raw_result_link = raw_result_link_search.group(1)
+    if _validate_results(FLAGS, test_summary):
+      break
+
+    attempt_num += 1
+
+
+def _parse_test_summary(FLAGS, ftl_cmd, result):
+    result_log = result.stdout.read()
+    logging.info("Test log: %s", result_log)
+
+    # Use Regex to filter the test information, Until we have better APIs.
+    # Generate test summary by using regex search ftl cmd logs
+    testapp_path = ""
+    testapp_path_search = re.search(r'Uploading \[(.*?)\] to Firebase Test Lab', result_log, re.MULTILINE | re.DOTALL)
+    if testapp_path_search:
+      testapp_path = testapp_path_search.group(1)
+
+    ftl_link = ""
+    ftl_link_search = re.search(r'Test results will be streamed to \[(.*?)\]', result_log, re.MULTILINE | re.DOTALL)
+    if ftl_link_search:
+      ftl_link = ftl_link_search.group(1)
   
-  outcome_device = []
-  # Test outcome pattern 1:
-  # ┌─────────┬──────────────────────────────┬─────────────────────┐
-  # │ OUTCOME │       TEST_AXIS_VALUE        │     TEST_DETAILS    │
-  # ├─────────┼──────────────────────────────┼─────────────────────┤
-  # │ Failed  │ iphone13pro-15.2-en-portrait │ 1 test cases failed │
-  # └─────────┴──────────────────────────────┴─────────────────────┘
-  outcome_device_search = re.findall(r'│(.*?)│(.*?)│(.*?)│', result_log, re.MULTILINE | re.DOTALL)
-  for o_d in outcome_device_search:
-    if 'OUTCOME' in o_d[0]: # skip the table title
-      continue
-    outcome_device.append({"device_axis": o_d[1].strip(), "outcome": o_d[0].strip()})
-  # Test outcome pattern 2:
-  # OUTCOME: Passed
-  # TEST_AXIS_VALUE: redfin-30-en-portrait
-  # TEST_DETAILS: --
-  outcome_device_search = re.findall(r'OUTCOME:(.*?)\nTEST_AXIS_VALUE:(.*?)\nTEST_DETAILS:', result_log, re.MULTILINE | re.DOTALL)
-  for o_d in outcome_device_search:
-    outcome_device.append({"device_axis": o_d[1].strip(), "outcome": o_d[0].strip()})
+    raw_result_link = ""
+    raw_result_link_search = re.search(r'Raw results will be stored in your GCS bucket at \[(.*?)\]', result_log, re.MULTILINE | re.DOTALL)
+    if raw_result_link_search:
+      raw_result_link = raw_result_link_search.group(1)
+    
+    outcome_device = []
+    # Test outcome pattern 1:
+    # ┌─────────┬──────────────────────────────┬─────────────────────┐
+    # │ OUTCOME │       TEST_AXIS_VALUE        │     TEST_DETAILS    │
+    # ├─────────┼──────────────────────────────┼─────────────────────┤
+    # │ Failed  │ iphone13pro-15.2-en-portrait │ 1 test cases failed │
+    # └─────────┴──────────────────────────────┴─────────────────────┘
+    outcome_device_search = re.findall(r'│(.*?)│(.*?)│(.*?)│', result_log, re.MULTILINE | re.DOTALL)
+    for o_d in outcome_device_search:
+      if 'OUTCOME' in o_d[0]: # skip the table title
+        continue
+      outcome_device.append({"device_axis": o_d[1].strip(), "outcome": o_d[0].strip()})
+    # Test outcome pattern 2:
+    # OUTCOME: Passed
+    # TEST_AXIS_VALUE: redfin-30-en-portrait
+    # TEST_DETAILS: --
+    outcome_device_search = re.findall(r'OUTCOME:(.*?)\nTEST_AXIS_VALUE:(.*?)\nTEST_DETAILS:', result_log, re.MULTILINE | re.DOTALL)
+    for o_d in outcome_device_search:
+      outcome_device.append({"device_axis": o_d[1].strip(), "outcome": o_d[0].strip()})
+    
+    return {
+      "cmd": ftl_cmd,
+      "return_code": result.returncode,
+      "testapp_path": testapp_path,
+      "test_type": FLAGS.test_type,
+      "ftl_link": ftl_link,
+      "raw_result_link":  raw_result_link,
+      "devices": outcome_device
+    }
 
-  while result.poll() is None:
-    time.sleep(1) # Process hasn't exited yet, let's wait some
-  # https://firebase.google.com/docs/test-lab/android/command-line#script_exit_codes
-  logging.info("Test done: %s\nReturned code: %s\n%s", ftl_cmd, result.returncode, result_log)
+
+def _validate_results(FLAGS, test_summary):
+  if test_summary.get("return_code") != 0:
+    return False
   
-  test_summary =  {
-    "cmd": ftl_cmd,
-    "return_code": result.returncode,
-    "testapp_path": testapp_path,
-    "test_type": FLAGS.test_type,
-    "ftl_link": ftl_link,
-    "raw_result_link":  raw_result_link,
-    "devices": outcome_device
-  }
-  tests_result.get('apps').append(test_summary)
+  if FLAGS.test_type == GAMELOOP and FLAGS.validator:
+    try:
+      module = os.path.splitext(FLAGS.validator)[0]
+      validator = imp.load_source(module, FLAGS.validator)
+      return validator.validate(test_summary)
+    except ImportError:
+      logging.error("ImportError with validator: %s", FLAGS.validator)
+
+  return True
 
 
 def _ftl_cmd_with_arg_group(FLAGS, arg_group):
@@ -328,19 +356,23 @@ def _exit_code(tests_result):
 def parse_cmdline_args():
   parser = argparse.ArgumentParser(description='FTL Test trigger.')
   parser.add_argument('-p', '--project_id',
-    default=None, help='Firebase Project ID..')
+    default=None, help='Firebase Project ID.')
   parser.add_argument('-a', '--arg_groups', 
     default=None, help='Arguments in a YAML-formatted argument file.')
   parser.add_argument('-d', '--testapp_dir',
     default=None, help='Testapps (apks, ipas, zips) in this directory will be tested.')
   parser.add_argument('-t', '--test_type',
     default=None, help='Test type that Firebase Test Lab will run..')
-  parser.add_argument('-m', '--test_devices',
+  parser.add_argument('--test_devices',
     default=None, help='Model id and device version for desired device. If none, will use FTL default.')
-  parser.add_argument('-o', '--timeout', 
+  parser.add_argument('--timeout', 
     default="600s", help='Timeout for one ftl test.')
-  parser.add_argument('-f', '--additional_flags', 
+  parser.add_argument('--additional_flags', 
     default=None, help='Additional flags that may be used.')
+  parser.add_argument('--max_attempts', 
+    default=1, type=int, help='Max attempts when test on FTL failed.')
+  parser.add_argument('--validator', 
+    default=None, help='Customized python script that validate one test app result.')
   args = parser.parse_args()
   if not (args.arg_groups or (args.testapp_dir and args.test_type)):
     raise ValueError("Must specify --arg_groups or (--testapp_dir and --test_type)")


### PR DESCRIPTION
1. User could provide log validator for game-loop test. 
2. Enabled retry logic for failed tests.
3. Added README.md

Test example: rerun firestore test after failure occurs:
https://github.com/firebase/firebase-cpp-sdk/runs/8123763179?check_suite_focus=true#step:12:4341
