### PR TITLE
Add option to run tests on 1 randomly-chosen device from the list.

### DIFF
--- a/firebase-test-lab/README.md
+++ b/firebase-test-lab/README.md
@@ -85,7 +85,7 @@ jobs:
             test_devices: model=redfin,version=30;model=oriole,version=33
     ```
 
--   `test_device_selection` [default: `all`]: Whether to run the tests on all test_devices (separated by semicolons) or a random selection. Allowed values: [`all`, `random`].
+-   `test_device_selection` [default: `all`]: Whether to run the tests on _all_ `test_devices` (separated by semicolons), or one randomly selected device from the list. Allowed values: [`all`, `random`].
 
 -   `timeout` [default: 600s]: The maximum duration you want your test to run. You can enter an integer to represent the duration in seconds, or an integer and enumeration to represent the duration as a longer unit of time. 
 

--- a/firebase-test-lab/README.md
+++ b/firebase-test-lab/README.md
@@ -85,7 +85,7 @@ jobs:
             test_devices: model=redfin,version=30;model=oriole,version=33
     ```
 
--   `test_device_selection` [default: `all`]: Whether to run the tests on _all_ `test_devices` (separated by semicolons), or one randomly selected device from the list. Allowed values: [`all`, `random`].
+-   `test_device_selection` [default: `all`]: Whether to run the tests on all devices listed in `test_devices` (separated by semicolons), or on one randomly selected device from the list. Allowed values: [`all`, `random`].
 
 -   `timeout` [default: 600s]: The maximum duration you want your test to run. You can enter an integer to represent the duration in seconds, or an integer and enumeration to represent the duration as a longer unit of time. 
 

--- a/firebase-test-lab/README.md
+++ b/firebase-test-lab/README.md
@@ -85,7 +85,7 @@ jobs:
             test_devices: model=redfin,version=30;model=oriole,version=33
     ```
 
--   `test_device_selection` [default: `all`]: Whether to run the tests on all devices listed in `test_devices` (separated by semicolons), or on one randomly selected device from the list. Allowed values: [`all`, `random`].
+-   `test_device_selection` [default: `all`]: Whether to run the tests on all devices listed in `test_devices` (separated by semicolons), or on one randomly-selected device from the list. Allowed values: [`all`, `random`].
 
 -   `timeout` [default: 600s]: The maximum duration you want your test to run. You can enter an integer to represent the duration in seconds, or an integer and enumeration to represent the duration as a longer unit of time. 
 

--- a/firebase-test-lab/README.md
+++ b/firebase-test-lab/README.md
@@ -85,6 +85,8 @@ jobs:
             test_devices: model=redfin,version=30;model=oriole,version=33
     ```
 
+-   `test_device_selection` [default: `all`]: Whether to run the tests on all test_devices (separated by semicolons) or a random selection. Allowed values: [`all`, `random`].
+
 -   `timeout` [default: 600s]: The maximum duration you want your test to run. You can enter an integer to represent the duration in seconds, or an integer and enumeration to represent the duration as a longer unit of time. 
 
 -   `additional_flags`: Additional [gcloud firebase test](https://cloud.google.com/sdk/gcloud/reference/firebase/test) flags and values that may be used. e.g. `--xcode-version=11.3` for XCTest. 

--- a/firebase-test-lab/action.yml
+++ b/firebase-test-lab/action.yml
@@ -36,6 +36,10 @@ inputs:
   test_devices:
     description: 'Device model used for testing. Separate by ";".'
     required: false
+  test_device_selection:
+    description: 'Whether to run on all test devices or a single randomly-chosen device. (all | random)'
+    default: 'all'
+    required: false
   timeout:
     description: 'Timeout for one FTL test.'
     default: '600s'
@@ -75,7 +79,7 @@ runs:
     - id: ftl_test
       shell: bash
       run: |
-        test_result=$(python $GITHUB_ACTION_PATH/trigger_ftl_tests.py --arg_groups="${{ inputs.arg_groups }}" --testapp_dir="${{ inputs.testapp_dir }}" --test_type="${{ inputs.test_type }}" --timeout="${{ inputs.timeout }}" --test_devices="${{ inputs.test_devices }}" --additional_flags="${{ inputs.additional_flags }}" --max_attempts="${{ inputs.max_attempts }}" --validator="${{ inputs.validator }}")
+        test_result=$(python $GITHUB_ACTION_PATH/trigger_ftl_tests.py --arg_groups="${{ inputs.arg_groups }}" --testapp_dir="${{ inputs.testapp_dir }}" --test_type="${{ inputs.test_type }}" --timeout="${{ inputs.timeout }}" --test_devices="${{ inputs.test_devices }}" --test_device_selection="${{ inputs.test_device_selection }}" --additional_flags="${{ inputs.additional_flags }}" --max_attempts="${{ inputs.max_attempts }}" --validator="${{ inputs.validator }}")
         
         # first character in test_result is the exit code (0 or 1); the rest are the JSON format test summary.
         if [[ ! -z ${test_result} ]]; then

--- a/firebase-test-lab/trigger_ftl_tests.py
+++ b/firebase-test-lab/trigger_ftl_tests.py
@@ -324,8 +324,12 @@ def _ftl_cmd_with_flags(FLAGS, testapp_path):
 
   test_flags.extend(["--type", FLAGS.test_type, "--timeout", FLAGS.timeout])
   if FLAGS.test_devices:
-    for device in FLAGS.test_devices.split(";"):
-      test_flags.extend(["--device", device])
+    test_device_list = FLAGS.test_devices.split(";")
+    if FLAGS.test_device_selection == "random":
+      test_flags.extend(["--device", random.choice(test_device_list)])
+    else:  # FLAGS.test_device_list == "all"
+      for device in test_device_list:
+        test_flags.extend(["--device", device])
   if FLAGS.additional_flags:
     test_flags.extend(FLAGS.additional_flags.split())
 

--- a/firebase-test-lab/trigger_ftl_tests.py
+++ b/firebase-test-lab/trigger_ftl_tests.py
@@ -287,12 +287,8 @@ def _ftl_cmd_with_arg_group(FLAGS, arg_group):
   cmd = TEST_ANDROID_CMD[:]
   test_flags = [arg_group, "--type", FLAGS.test_type, "--timeout", FLAGS.timeout]
   if FLAGS.test_devices:
-    test_device_list = FLAGS.test_devices.split(";")
-    if FLAGS.test_device_selection == "random":
-      test_flags.extend(["--device", random.choice(test_device_list)])
-    else:  # FLAGS.test_device_list == "all"
-      for device in test_device_list:
-        test_flags.extend(["--device", device])
+    for device in FLAGS.test_devices.split(";"):
+      test_flags.extend(["--device", device])
   if FLAGS.additional_flags:
     test_flags.extend(FLAGS.additional_flags.split())
 

--- a/firebase-test-lab/trigger_ftl_tests.py
+++ b/firebase-test-lab/trigger_ftl_tests.py
@@ -24,16 +24,16 @@ Usage:
   python trigger_ftl_tests.py --testapp_dir ~/testapps --test_type xctest
 
 This will recursively search testapps under dir "~/testapps" for apks, ipas,
-and zips, send them to FTL, and generate test summary: 
+and zips, send them to FTL, and generate test summary:
 
 TO-DO: For android instrumentation testapps, needs better design
-Note: Currently, please compress both apks in a zip file and make sure the 
-test apk name contains string "test" and the app apk doesn't. e.g. 
-  
+Note: Currently, please compress both apks in a zip file and make sure the
+test apk name contains string "test" and the app apk doesn't. e.g.
+
   app-debug-unaligned.apk & app-debug-test-unaligned.apk -> app.zip
 
-Anrdoid robo tests & instrumentation tests also accept arguments in a 
-YAML-formatted argument file. For more information: 
+Anrdoid robo tests & instrumentation tests also accept arguments in a
+YAML-formatted argument file. For more information:
 https://cloud.google.com/sdk/gcloud/reference/topic/arg-files
 
 Summary example:
@@ -65,23 +65,24 @@ following commands:
   gcloud firebase test android models list
   gcloud firebase test ios models list
 
-Note: you need the value in the MODEL_ID column, not MODEL_NAME. 
+Note: you need the value in the MODEL_ID column, not MODEL_NAME.
 Examples:
 Test on two iOS devices:
   --test_devices "model=iphone8,version=13.6;model=iphone8,version=14.7"
 
 """
 
+import argparse
+import imp
+import json
+import logging
 import os
+import platform
+import random
 import re
 import subprocess
 import threading
-import platform
 import time
-import argparse
-import logging
-import json
-import imp
 
 from zipfile import ZipFile
 
@@ -109,7 +110,7 @@ def main():
   FLAGS = parse_cmdline_args()
   tests_result = _run_test_on_ftl(FLAGS)
   logging.info("All Tests Done:\n%s" % json.dumps(tests_result, indent=2))
-  exit_code = _exit_code(tests_result) 
+  exit_code = _exit_code(tests_result)
   print("%s %s" % (exit_code, json.dumps(tests_result)))
 
 
@@ -151,7 +152,7 @@ def _fix_path(path):
 def _run_test_on_ftl(FLAGS):
   # Generate ftl cmd for each testapps
   ftl_cmd_list = []
-  
+
   if FLAGS.testapp_dir and FLAGS.test_type:
     testapps = _search_testapps(FLAGS.testapp_dir, FLAGS.test_type)
     if not testapps:
@@ -193,7 +194,7 @@ def _ftl_run(FLAGS, ftl_cmd, tests_result):
         args=ftl_cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        universal_newlines=True, 
+        universal_newlines=True,
         shell=True)
     while result.poll() is None:
       time.sleep(1) # Process hasn't exited yet, let's wait some
@@ -225,12 +226,12 @@ def _parse_test_summary(FLAGS, ftl_cmd, result, attempt_num):
     ftl_link_search = re.search(r'Test results will be streamed to \[(.*?)\]', result_log, re.MULTILINE | re.DOTALL)
     if ftl_link_search:
       ftl_link = ftl_link_search.group(1)
-  
+
     raw_result_link = ""
     raw_result_link_search = re.search(r'Raw results will be stored in your GCS bucket at \[(.*?)\]', result_log, re.MULTILINE | re.DOTALL)
     if raw_result_link_search:
       raw_result_link = raw_result_link_search.group(1)
-    
+
     outcome_device = []
     # Test outcome pattern 1:
     # ┌─────────┬──────────────────────────────┬─────────────────────┐
@@ -250,7 +251,7 @@ def _parse_test_summary(FLAGS, ftl_cmd, result, attempt_num):
     outcome_device_search = re.findall(r'OUTCOME:(.*?)\nTEST_AXIS_VALUE:(.*?)\nTEST_DETAILS:', result_log, re.MULTILINE | re.DOTALL)
     for o_d in outcome_device_search:
       outcome_device.append({"device_axis": o_d[1].strip(), "outcome": o_d[0].strip()})
-    
+
     return {
       "attempt": attempt_num,
       "cmd": ftl_cmd,
@@ -267,7 +268,7 @@ def _validate_results(FLAGS, test_summary):
   """Returns True if all tests passed; False otherwise"""
   if test_summary.get("return_code") != 0:
     return False
-  
+
   if FLAGS.test_type == GAMELOOP and FLAGS.validator:
     try:
       # [Experimental] This is for game-loop test only, which could validate test result for one app.
@@ -286,8 +287,12 @@ def _ftl_cmd_with_arg_group(FLAGS, arg_group):
   cmd = TEST_ANDROID_CMD[:]
   test_flags = [arg_group, "--type", FLAGS.test_type, "--timeout", FLAGS.timeout]
   if FLAGS.test_devices:
-    for device in FLAGS.test_devices.split(";"):
-      test_flags.extend(["--device", device])
+    test_device_list = FLAGS.test_devices.split(";"):
+    if FLAGS.test_device_selection == "random":
+      test_flags.extend(["--device", random.choice(test_device_list)])
+    else:  # FLAGS.test_device_list == "all"
+      for device in test_device_list:
+        test_flags.extend(["--device", device])
   if FLAGS.additional_flags:
     test_flags.extend(FLAGS.additional_flags.split())
 
@@ -328,8 +333,8 @@ def _ftl_cmd_with_flags(FLAGS, testapp_path):
   return cmd
 
 
-def _extract_instrumentation_test(zip_path): 
-  # Android instrumentation tests requires two apks. 
+def _extract_instrumentation_test(zip_path):
+  # Android instrumentation tests requires two apks.
   # https://firebase.google.com/docs/test-lab/android/command-line#running_your_instrumentation_tests
   # Please make sure the test apk name contains string "test" and the app apk doesn't.
   with ZipFile(zip_path, 'r') as zipObj:
@@ -347,7 +352,7 @@ def _extract_instrumentation_test(zip_path):
 
 
 def _exit_code(tests_result):
-  """0: all tests passed; 1: some tests failed.""" 
+  """0: all tests passed; 1: some tests failed."""
   if not tests_result.get("apps"):
     return 1
 
@@ -363,7 +368,7 @@ def parse_cmdline_args():
   parser = argparse.ArgumentParser(description='FTL Test trigger.')
   parser.add_argument('-p', '--project_id',
     default=None, help='Firebase Project ID.')
-  parser.add_argument('-a', '--arg_groups', 
+  parser.add_argument('-a', '--arg_groups',
     default=None, help='Arguments in a YAML-formatted argument file.')
   parser.add_argument('-d', '--testapp_dir',
     default=None, help='Testapps (apks, ipas, zips) in this directory will be tested.')
@@ -371,13 +376,16 @@ def parse_cmdline_args():
     default=None, help='Test type that Firebase Test Lab will run..')
   parser.add_argument('--test_devices',
     default=None, help='Model id and device version for desired device. If none, will use FTL default.')
-  parser.add_argument('--timeout', 
+  parser.add_argument('--test_device_selection',
+    default='all', choices=['all', 'random'],
+    help='Whether to run on all test_devices or on one random device.')
+  parser.add_argument('--timeout',
     default="600s", help='Timeout for one ftl test.')
-  parser.add_argument('--additional_flags', 
+  parser.add_argument('--additional_flags',
     default=None, help='Additional flags that may be used.')
-  parser.add_argument('--max_attempts', 
+  parser.add_argument('--max_attempts',
     default=1, type=int, help='Max attempts when test on FTL failed.')
-  parser.add_argument('--validator', 
+  parser.add_argument('--validator',
     default=None, help='Customized python script that validate one test app result.')
   args = parser.parse_args()
   if not (args.arg_groups or (args.testapp_dir and args.test_type)):

--- a/firebase-test-lab/trigger_ftl_tests.py
+++ b/firebase-test-lab/trigger_ftl_tests.py
@@ -287,7 +287,7 @@ def _ftl_cmd_with_arg_group(FLAGS, arg_group):
   cmd = TEST_ANDROID_CMD[:]
   test_flags = [arg_group, "--type", FLAGS.test_type, "--timeout", FLAGS.timeout]
   if FLAGS.test_devices:
-    test_device_list = FLAGS.test_devices.split(";"):
+    test_device_list = FLAGS.test_devices.split(";")
     if FLAGS.test_device_selection == "random":
       test_flags.extend(["--device", random.choice(test_device_list)])
     else:  # FLAGS.test_device_list == "all"


### PR DESCRIPTION
Due to hiccups in FTL availability, sometimes you may want to distribute your test runs onto different FTL device types.

This option allows you to pass in a list of test_devices, but rather than running the test on *all* devices in the list, you can run the tests on one randomly-chosen device from the list instead.