### PR TITLE
Update google-github-actions

### DIFF
--- a/firebase-test-lab/action.yml
+++ b/firebase-test-lab/action.yml
@@ -66,13 +66,13 @@ runs:
   using: 'composite'
   steps:
     # Setup GCould Env if account infomation was provided
-    - uses: 'google-github-actions/auth@v0'
+    - uses: 'google-github-actions/auth@v2'
       if: (inputs.workload_identity_provider && inputs.service_account) || inputs.credentials_json
       with:
         credentials_json: '${{ inputs.credentials_json }}'
         workload_identity_provider: '${{ inputs.workload_identity_provider }}'
         service_account: '${{ inputs.service_account }}'
-    - uses: google-github-actions/setup-gcloud@v0
+    - uses: google-github-actions/setup-gcloud@v1
       if: (inputs.workload_identity_provider && inputs.service_account) || inputs.credentials_json
       with:
         install_components: 'beta'


### PR DESCRIPTION
Update `google-github-actions`

The v0 series of google-github-actions/auth is no longer maintained. 
https://github.com/firebase/firebase-ios-sdk/actions/runs/7095287892/job/19311952340#step:9:40